### PR TITLE
A simple series of benchmarks to see the trade-offs with vtable storage options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "vtable_bench"
+version = "0.1.0"
+authors = ["Laurence Tratt <laurie@tratt.net>"]
+edition = "2018"
+
+[dependencies]
+rand = "0.6"
+statistical = "1.0"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# vtable_bench
+
+This is a series of benchmarks designed to give some understanding of how
+performance in Rust programs depending on whether the vtable pointer is stored
+alongside the normal pointer (a "fat pointer") or next to the object itself.
+
+Run as follows:
+
+```
+$ cargo build --release && cargo run --release --bin vtable_bench
+```
+
+
+# Why this is worth measuring
+
+Trait objects' vtables are passed around as fat pointers. If they're used
+rarely, this seems unlikely to make much performance difference either way.
+However, if we're expecting to have a reasonably large number of trait objects,
+it's not obvious if fat pointers (2 machine words) are a better trade-off vs.
+storing the vtable pointer in the object itself (making pointers 1 machine
+word at the cost of an indirection to access the vtable).
+
+These benchmarks are an attempt to start understanding the performance
+trade-offs. They are highly simplistic, and inevitably only tell us about a
+small handful of possible performance points. They might be better than
+nothing, however.
+
+Each benchmark creates one or more trait objects, puts them in a vector, and
+then iterates over that vector calling a method:
+
+* The `normal` benchmarks use fat pointers and the `alongside` benchmarks store
+  the vtable alongside the data itself (recreating fat pointers on an as-needed
+  basis).
+
+* The `multiref` benchmarks allocate a single box and multiply alias it;
+  non-`multiref` benchmarks allocate multiple boxes without aliasing.
+
+* The `no_read` benchmarks do not read from self (they return a fixed integer);
+  `with_read` benchmarks do read from self. This is trying to understand whether
+  bringing a trait object into cache by reading its vtable offsets the later
+  read.
+
+The runner is fairly simplistic, but runs each benchmark in its own process
+(with 30 process executions and 100 in-process iterations), printing means and
+99% confidence intervals (calculated from the standard deviation).

--- a/src/bin/bench_alongside_multiref_no_read.rs
+++ b/src/bin/bench_alongside_multiref_no_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_alongside_multiref_no_read();
+}

--- a/src/bin/bench_alongside_multiref_with_read.rs
+++ b/src/bin/bench_alongside_multiref_with_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_alongside_multiref_with_read();
+}

--- a/src/bin/bench_alongside_no_read.rs
+++ b/src/bin/bench_alongside_no_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_alongside_no_read();
+}

--- a/src/bin/bench_alongside_with_read.rs
+++ b/src/bin/bench_alongside_with_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_alongside_with_read();
+}

--- a/src/bin/bench_normal_multiref_no_read.rs
+++ b/src/bin/bench_normal_multiref_no_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_normal_multiref_no_read();
+}

--- a/src/bin/bench_normal_multiref_with_read.rs
+++ b/src/bin/bench_normal_multiref_with_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_normal_multiref_with_read();
+}

--- a/src/bin/bench_normal_no_read.rs
+++ b/src/bin/bench_normal_no_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_normal_no_read();
+}

--- a/src/bin/bench_normal_with_read.rs
+++ b/src/bin/bench_normal_with_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_normal_with_read();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,259 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+#![feature(alloc_layout_extra)]
+#![feature(allocator_api)]
+
+use std::alloc::{alloc, Layout};
+use std::mem::{size_of, transmute};
+use std::time::Instant;
+
+const ITERS: usize = 100;
+const VEC_SIZE: usize = 10000000;
+const VAL_NOREAD: usize = 0xdeadbeef;
+const VAL_WITHREAD: usize = 0xFEEDC0DE;
+
+#[inline(never)]
+fn time<F>(mut f: F)
+where
+    F: FnMut(),
+{
+    let before = Instant::now();
+    for _ in 0..ITERS {
+        f();
+    }
+    let d = Instant::now() - before;
+    println!("{:?}", d.as_secs() as f64 + d.subsec_nanos() as f64 * 1e-9);
+}
+
+// The trait whose function we'll dynamically look up.
+trait GetVal {
+    fn val(&self) -> usize;
+}
+
+// This is a simple helper trait that lets us cut a lot of our code in half below: it allows us to
+// instantiate SNoRead or SWithRead via a trait. We can't put this in GetVal because GetVal then
+// wouldn't be a valid trait object.
+trait New {
+    fn new() -> Self;
+}
+
+// SNoRead and SWithRead are the same size, but SNoRead.val() doesn't actually read the "_i"
+// attribute (hence the leading underscore) whereas SWithRead does read from its "i" attribute
+// (hence the lack of a leading underscore).
+struct SNoRead {
+    _i: usize,
+}
+
+impl GetVal for SNoRead {
+    fn val(&self) -> usize {
+        VAL_NOREAD
+    }
+}
+
+impl New for SNoRead {
+    fn new() -> Self {
+        SNoRead { _i: VAL_NOREAD }
+    }
+}
+
+struct SWithRead {
+    i: usize,
+}
+
+impl GetVal for SWithRead {
+    fn val(&self) -> usize {
+        self.i
+    }
+}
+
+impl New for SWithRead {
+    fn new() -> Self {
+        SWithRead { i: VAL_WITHREAD }
+    }
+}
+
+fn vec_normal<S: 'static + New + GetVal>() -> Vec<Box<dyn GetVal>> {
+    let mut v = Vec::<Box<dyn GetVal>>::with_capacity(VEC_SIZE);
+    for _ in 0..VEC_SIZE {
+        v.push(Box::new(S::new()));
+    }
+    v
+}
+
+pub fn bench_normal_no_read() {
+    assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
+    assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
+    let v = vec_normal::<SNoRead>();
+    time(|| {
+        for e in &v {
+            assert_eq!(e.val(), VAL_NOREAD);
+        }
+    });
+}
+
+pub fn bench_normal_with_read() {
+    assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
+    assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
+    let v = vec_normal::<SWithRead>();
+    time(|| {
+        for e in &v {
+            assert_eq!(e.val(), VAL_WITHREAD);
+        }
+    });
+}
+
+fn vec_multiref<S: 'static + New + GetVal>() -> Vec<*mut dyn GetVal> {
+    vec![Box::into_raw(Box::new(S::new())); VEC_SIZE]
+}
+
+fn clean_vec_multiref(v: Vec<*mut dyn GetVal>) {
+    unsafe { Box::from_raw(v[0]); }
+}
+
+pub fn bench_normal_multiref_no_read() {
+    assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
+    assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
+    let v = vec_multiref::<SNoRead>();
+    time(|| {
+        for &e in &v {
+            assert_eq!(unsafe { (&*e).val() }, VAL_NOREAD);
+        }
+    });
+    clean_vec_multiref(v);
+}
+
+pub fn bench_normal_multiref_with_read() {
+    assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
+    assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
+    let v = vec_multiref::<SWithRead>();
+    time(|| {
+        for &e in &v {
+            assert_eq!(unsafe { (&*e).val() }, VAL_WITHREAD);
+        }
+    });
+    clean_vec_multiref(v);
+}
+
+fn vec_vtable<S: 'static + New + GetVal>() -> Vec<*mut u8> {
+    assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
+    assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
+    let mut v = Vec::with_capacity(VEC_SIZE);
+    // Since every instance of S will share the same vtable, it's OK for us to pull it out and
+    // reuse it. With the coerce_unsized feature turned on, we can do this in a marginally cleverer
+    // way, but the outcome is the same.
+    let vtable = {
+        let b: *const dyn GetVal = Box::into_raw(Box::new(S::new()));
+        let (_, vtable) = unsafe { transmute::<_, (usize, usize)>(b) };
+        vtable
+    };
+    // We're going to lay out memory (on a 64-bit machine) as:
+    //   offset 0: vtable
+    //          8: S
+    let (layout, _) = Layout::new::<usize>().extend(Layout::new::<S>()).unwrap();
+    // The following assert ensure that the layout really is as we expect.
+    assert_eq!(layout.size(), size_of::<usize>() + size_of::<S>());
+    for _ in 0..VEC_SIZE {
+        let b = unsafe {
+            let b: *mut usize = alloc(layout) as *mut usize;
+            b.copy_from(&vtable, 1);
+            (b.add(1) as *mut S).copy_from(&S::new(), 1);
+            b as *mut u8
+        };
+        v.push(b);
+    }
+    v
+}
+
+fn clean_vec_vtable(v: Vec<*mut u8>) {
+    for e in v {
+        unsafe { Box::from_raw(e); }
+    }
+}
+
+pub fn bench_alongside_no_read() {
+    let v = vec_vtable::<SNoRead>();
+    time(|| {
+        for &e in &v {
+            let vtable = unsafe { *(e as *const usize) };
+            let t_ptr = unsafe { (e as *const usize).add(1) };
+            let b: *const dyn GetVal = unsafe { transmute((t_ptr, vtable)) };
+            assert_eq!(unsafe { (&*b).val() }, VAL_NOREAD);
+        }
+    });
+    clean_vec_vtable(v);
+}
+
+pub fn bench_alongside_with_read() {
+    let v = vec_vtable::<SWithRead>();
+    time(|| {
+        for &e in &v {
+            let vtable = unsafe { *(e as *const usize) };
+            let t_ptr = unsafe { (e as *const usize).add(1) };
+            let b: *const dyn GetVal = unsafe { transmute((t_ptr, vtable)) };
+            assert_eq!(unsafe { (&*b).val() }, VAL_WITHREAD);
+        }
+    });
+    clean_vec_vtable(v);
+}
+
+fn vec_multiref_vtable<S: 'static + New + GetVal>() -> Vec<*mut u8> {
+    let mut v = Vec::with_capacity(VEC_SIZE);
+    let vtable = {
+        let b: *const dyn GetVal = Box::into_raw(Box::new(S::new()));
+        let (_, vtable) = unsafe { transmute::<_, (usize, usize)>(b) };
+        vtable
+    };
+    let ptr = {
+        let (layout, _) = Layout::new::<usize>().extend(Layout::new::<S>()).unwrap();
+        assert_eq!(layout.size(), size_of::<usize>() + size_of::<S>());
+        let b = unsafe {
+            let b: *mut usize = alloc(layout) as *mut usize;
+            b.copy_from(&vtable, 1);
+            (b.add(1) as *mut S).copy_from(&S::new(), 1);
+            b as *mut S as *mut dyn GetVal
+        };
+        let (ptr, _) = unsafe { transmute::<_, (*mut u8, usize)>(b) };
+        ptr
+    };
+    for _ in 0..VEC_SIZE {
+        v.push(ptr);
+    }
+    v
+}
+
+fn clean_multiref_table(v: Vec<*mut u8>) {
+    unsafe { Box::from_raw(v[0]); }
+}
+
+pub fn bench_alongside_multiref_no_read() {
+    let v = vec_multiref_vtable::<SNoRead>();
+    time(|| {
+        for &e in &v {
+            let vtable = unsafe { *(e as *const usize) };
+            let t_ptr = unsafe { (e as *const usize).add(1) };
+            let b: *const dyn GetVal = unsafe { transmute((t_ptr, vtable)) };
+            assert_eq!(unsafe { (&*b).val() }, VAL_NOREAD);
+        }
+    });
+    clean_multiref_table(v);
+}
+
+pub fn bench_alongside_multiref_with_read() {
+    let v = vec_multiref_vtable::<SWithRead>();
+    time(|| {
+        for &e in &v {
+            let vtable = unsafe { *(e as *const usize) };
+            let t_ptr = unsafe { (e as *const usize).add(1) };
+            let b: *const dyn GetVal = unsafe { transmute((t_ptr, vtable)) };
+            assert_eq!(unsafe { (&*b).val() }, VAL_WITHREAD);
+        }
+    });
+    clean_multiref_table(v);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+use std::fs::read_dir;
+use std::io::{self, Write};
+use std::process::Command;
+
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use statistical::{mean, standard_deviation};
+
+const REPS: usize = 30;
+
+fn mean_ci(d: &Vec<f64>) -> (f64, f64) {
+    let m = mean(d);
+    let sd = standard_deviation(d, None);
+    // Calculate a 99% confidence based on the mean and standard deviation.
+    (m, 2.58 * (sd / (d.len() as f64).sqrt()))
+}
+
+fn main() {
+    let bmark_names = read_dir("src/bin/")
+        .unwrap()
+        .map(|x| {
+            x.unwrap()
+                .path()
+                .file_stem()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_owned()
+        })
+        .collect::<Vec<_>>();
+    let mut bmark_data: HashMap<_, Vec<f64>> = HashMap::new();
+    for bn in &bmark_names {
+        bmark_data.insert(bn, vec![]);
+    }
+    let mut rng = thread_rng();
+    let mut done = 0;
+    while done < bmark_names.len() * REPS {
+        // Randomly select a benchmark to run next
+        let bn = loop {
+            let cnd = bmark_names.choose(&mut rng).unwrap();
+            if bmark_data[cnd].len() < REPS {
+                break cnd;
+            }
+        };
+
+        let output = Command::new(format!("target/release/{}", bn))
+            .output()
+            .expect(&format!("Couldn't run {}", bn));
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let t = stdout.trim().parse::<f64>().unwrap();
+        bmark_data.get_mut(&bn).unwrap().push(t);
+        done += 1;
+        print!(".");
+        io::stdout().flush().ok();
+    }
+    println!();
+    let mut bmark_names_sorted = bmark_names.clone();
+    bmark_names_sorted.sort();
+    for bn in &bmark_names_sorted {
+        let (mean, ci) = mean_ci(&bmark_data[&bn]);
+        println!("{}: {:.3} +/- {:.4}", bn, mean, ci);
+    }
+}


### PR DESCRIPTION
Trait objects' vtables are passed around as fat pointers. If they're used rarely, this seems unlikely to make much performance difference either way. However, if we have lots of trait objects, and if we're expecting to have a reasonably large number of trait objects, and for many of those to be multiply aliased, it's not obvious if fat pointers are a better trade-off vs.
storing the vtable pointer in the object itself.

These benchmarks are an attempt to start understanding the performance trade-offs. They are highly simplistic, and I don't yet fully understand all the numbers I'm seeing. It would be useful, therefore, to see what others think!

Each benchmark creates one or more trait objects, puts them in a vector, and then iterates over that vector calling a method.

The "normal" benchmarks use fat pointers and the "alongside" benchmarks store the vtable alongside the data itself (recreating fat pointers on an as-needed basis).

The "multiref" benchmarks allocate a single box and multiply alias it; non-"multiref" benchmarks allocate multiple boxes without allocation.

The "no_read" benchmarks do not read from self (they return a fixed integer); "with_read" benchmarks do read from self. This is trying to understand whether bringing a trait object into cache by reading its vtable offsets the later read.

The runner is fairly simplistic, but runs each benchmark in its own process (with 30 process executions and 100 in-process iterations), printing means and 99% confidence intervals (calculated from the standard deviation).

Here's a run from bencher10:

```
  bench_alongside_multiref_no_read: 1.672 +/- 0.0213
  bench_alongside_multiref_with_read: 1.671 +/- 0.0031
  bench_alongside_no_read: 2.168 +/- 0.0065
  bench_alongside_with_read: 2.176 +/- 0.0089
  bench_normal_multiref_no_read: 1.493 +/- 0.0091
  bench_normal_multiref_with_read: 1.519 +/- 0.0097
  bench_normal_no_read: 1.493 +/- 0.0086
  bench_normal_with_read: 2.148 +/- 0.0115
```

It might be easier to look at like this:

```
  bench_normal_no_read: 1.493 +/- 0.0086
  bench_alongside_no_read: 2.168 +/- 0.0065

  bench_normal_with_read: 2.148 +/- 0.0115
  bench_alongside_with_read: 2.176 +/- 0.0089

  bench_normal_multiref_no_read: 1.493 +/- 0.0091
  bench_alongside_multiref_no_read: 1.672 +/- 0.0213

  bench_normal_multiref_with_read: 1.519 +/- 0.0097
  bench_alongside_multiref_with_read: 1.671 +/- 0.0031
```

So "alongside" loses at everything except bench_alongside_with_read where it's neck-and-neck with bench_normal_with_read.

Are these benchmarks sufficiently representative? Honestly, I don't know...