### PR TITLE
Various tidy ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ then iterates over that vector calling a method:
   the vtable alongside the data itself (recreating fat pointers on an as-needed
   basis).
 
-* The `multiref` benchmarks allocate a single box and multiply alias it;
-  non-`multiref` benchmarks allocate multiple boxes without aliasing.
+* The `multialias` benchmarks allocate a single box and multiply alias it;
+  non-`multialias` benchmarks allocate multiple boxes without aliasing.
 
 * The `no_read` benchmarks do not read from self (they return a fixed integer);
   `with_read` benchmarks do read from self. This is trying to understand whether
@@ -67,39 +67,39 @@ easier).
 
 ```
 $ cargo run --release --bin vtable_bench 30 10000 100000
-bench_innervtable_multiref_no_read: 1.627 +/- 0.0002
-bench_innervtable_multiref_with_read: 1.631 +/- 0.0100
+bench_innervtable_multialias_no_read: 1.627 +/- 0.0002
+bench_innervtable_multialias_with_read: 1.631 +/- 0.0100
 bench_innervtable_no_read: 1.483 +/- 0.0040
 bench_innervtable_with_read: 1.536 +/- 0.0043
-bench_fat_multiref_no_read: 1.629 +/- 0.0049
-bench_fat_multiref_with_read: 1.627 +/- 0.0007
+bench_fat_multialias_no_read: 1.629 +/- 0.0049
+bench_fat_multialias_with_read: 1.627 +/- 0.0007
 bench_fat_no_read: 1.628 +/- 0.0015
 bench_fat_with_read: 1.669 +/- 0.0051
 $ cargo run --release --bin vtable_bench 30 1000 1000000
-bench_innervtable_multiref_no_read: 1.649 +/- 0.0198
-bench_innervtable_multiref_with_read: 1.644 +/- 0.0104
+bench_innervtable_multialias_no_read: 1.649 +/- 0.0198
+bench_innervtable_multialias_with_read: 1.644 +/- 0.0104
 bench_innervtable_no_read: 2.063 +/- 0.0086
 bench_innervtable_with_read: 2.098 +/- 0.0123
-bench_fat_multiref_no_read: 1.704 +/- 0.0053
-bench_fat_multiref_with_read: 1.700 +/- 0.0007
+bench_fat_multialias_no_read: 1.704 +/- 0.0053
+bench_fat_multialias_with_read: 1.700 +/- 0.0007
 bench_fat_no_read: 1.707 +/- 0.0131
 bench_fat_with_read: 2.188 +/- 0.0125
 $ cargo run --release --bin vtable_bench 30 100 10000000
-bench_innervtable_multiref_no_read: 1.666 +/- 0.0082
-bench_innervtable_multiref_with_read: 1.666 +/- 0.0121
+bench_innervtable_multialias_no_read: 1.666 +/- 0.0082
+bench_innervtable_multialias_with_read: 1.666 +/- 0.0121
 bench_innervtable_no_read: 2.077 +/- 0.0205
 bench_innervtable_with_read: 2.100 +/- 0.0126
-bench_fat_multiref_no_read: 1.699 +/- 0.0014
-bench_fat_multiref_with_read: 1.702 +/- 0.0061
+bench_fat_multialias_no_read: 1.699 +/- 0.0014
+bench_fat_multialias_with_read: 1.702 +/- 0.0061
 bench_fat_no_read: 1.698 +/- 0.0059
 bench_fat_with_read: 2.184 +/- 0.0059
 $ cargo run --release --bin vtable_bench 30 10 100000000
-bench_innervtable_multiref_no_read: 1.663 +/- 0.0082
-bench_innervtable_multiref_with_read: 1.672 +/- 0.0230
+bench_innervtable_multialias_no_read: 1.663 +/- 0.0082
+bench_innervtable_multialias_with_read: 1.672 +/- 0.0230
 bench_innervtable_no_read: 2.076 +/- 0.0141
 bench_innervtable_with_read: 2.112 +/- 0.0160
-bench_fat_multiref_no_read: 1.709 +/- 0.0115
-bench_fat_multiref_with_read: 1.701 +/- 0.0025
+bench_fat_multialias_no_read: 1.709 +/- 0.0115
+bench_fat_multialias_with_read: 1.701 +/- 0.0025
 bench_fat_no_read: 1.702 +/- 0.0012
 bench_fat_with_read: 2.196 +/- 0.0065
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ nothing, however.
 Each benchmark creates one or more trait objects, puts them in a vector, and
 then iterates over that vector calling a method:
 
-* The `normal` benchmarks use fat pointers and the `alongside` benchmarks store
+* The `fat` benchmarks use fat pointers and the `alongside` benchmarks store
   the vtable alongside the data itself (recreating fat pointers on an as-needed
   basis).
 
@@ -70,35 +70,35 @@ bench_alongside_multiref_no_read: 1.627 +/- 0.0002
 bench_alongside_multiref_with_read: 1.631 +/- 0.0100
 bench_alongside_no_read: 1.483 +/- 0.0040
 bench_alongside_with_read: 1.536 +/- 0.0043
-bench_normal_multiref_no_read: 1.629 +/- 0.0049
-bench_normal_multiref_with_read: 1.627 +/- 0.0007
-bench_normal_no_read: 1.628 +/- 0.0015
-bench_normal_with_read: 1.669 +/- 0.0051
+bench_fat_multiref_no_read: 1.629 +/- 0.0049
+bench_fat_multiref_with_read: 1.627 +/- 0.0007
+bench_fat_no_read: 1.628 +/- 0.0015
+bench_fat_with_read: 1.669 +/- 0.0051
 $ cargo run --release --bin vtable_bench 30 1000 1000000
 bench_alongside_multiref_no_read: 1.649 +/- 0.0198
 bench_alongside_multiref_with_read: 1.644 +/- 0.0104
 bench_alongside_no_read: 2.063 +/- 0.0086
 bench_alongside_with_read: 2.098 +/- 0.0123
-bench_normal_multiref_no_read: 1.704 +/- 0.0053
-bench_normal_multiref_with_read: 1.700 +/- 0.0007
-bench_normal_no_read: 1.707 +/- 0.0131
-bench_normal_with_read: 2.188 +/- 0.0125
+bench_fat_multiref_no_read: 1.704 +/- 0.0053
+bench_fat_multiref_with_read: 1.700 +/- 0.0007
+bench_fat_no_read: 1.707 +/- 0.0131
+bench_fat_with_read: 2.188 +/- 0.0125
 $ cargo run --release --bin vtable_bench 30 100 10000000
 bench_alongside_multiref_no_read: 1.666 +/- 0.0082
 bench_alongside_multiref_with_read: 1.666 +/- 0.0121
 bench_alongside_no_read: 2.077 +/- 0.0205
 bench_alongside_with_read: 2.100 +/- 0.0126
-bench_normal_multiref_no_read: 1.699 +/- 0.0014
-bench_normal_multiref_with_read: 1.702 +/- 0.0061
-bench_normal_no_read: 1.698 +/- 0.0059
-bench_normal_with_read: 2.184 +/- 0.0059
+bench_fat_multiref_no_read: 1.699 +/- 0.0014
+bench_fat_multiref_with_read: 1.702 +/- 0.0061
+bench_fat_no_read: 1.698 +/- 0.0059
+bench_fat_with_read: 2.184 +/- 0.0059
 $ cargo run --release --bin vtable_bench 30 10 100000000
 bench_alongside_multiref_no_read: 1.663 +/- 0.0082
 bench_alongside_multiref_with_read: 1.672 +/- 0.0230
 bench_alongside_no_read: 2.076 +/- 0.0141
 bench_alongside_with_read: 2.112 +/- 0.0160
-bench_normal_multiref_no_read: 1.709 +/- 0.0115
-bench_normal_multiref_with_read: 1.701 +/- 0.0025
-bench_normal_no_read: 1.702 +/- 0.0012
-bench_normal_with_read: 2.196 +/- 0.0065
+bench_fat_multiref_no_read: 1.709 +/- 0.0115
+bench_fat_multiref_with_read: 1.701 +/- 0.0025
+bench_fat_no_read: 1.702 +/- 0.0012
+bench_fat_with_read: 2.196 +/- 0.0065
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This is a series of benchmarks designed to give some understanding of how
 performance in Rust programs depending on whether the vtable pointer is stored
-alongside the normal pointer (a "fat pointer") or next to the object itself.
+alongside the normal pointer (a "fat pointer") or next to the object itself
+("inner vtable pointers").
 
 You can perform a run with default values as follows:
 
@@ -28,7 +29,7 @@ nothing, however.
 Each benchmark creates one or more trait objects, puts them in a vector, and
 then iterates over that vector calling a method:
 
-* The `fat` benchmarks use fat pointers and the `alongside` benchmarks store
+* The `fat` benchmarks use fat pointers and the `innervtable` benchmarks store
   the vtable alongside the data itself (recreating fat pointers on an as-needed
   basis).
 
@@ -66,37 +67,37 @@ easier).
 
 ```
 $ cargo run --release --bin vtable_bench 30 10000 100000
-bench_alongside_multiref_no_read: 1.627 +/- 0.0002
-bench_alongside_multiref_with_read: 1.631 +/- 0.0100
-bench_alongside_no_read: 1.483 +/- 0.0040
-bench_alongside_with_read: 1.536 +/- 0.0043
+bench_innervtable_multiref_no_read: 1.627 +/- 0.0002
+bench_innervtable_multiref_with_read: 1.631 +/- 0.0100
+bench_innervtable_no_read: 1.483 +/- 0.0040
+bench_innervtable_with_read: 1.536 +/- 0.0043
 bench_fat_multiref_no_read: 1.629 +/- 0.0049
 bench_fat_multiref_with_read: 1.627 +/- 0.0007
 bench_fat_no_read: 1.628 +/- 0.0015
 bench_fat_with_read: 1.669 +/- 0.0051
 $ cargo run --release --bin vtable_bench 30 1000 1000000
-bench_alongside_multiref_no_read: 1.649 +/- 0.0198
-bench_alongside_multiref_with_read: 1.644 +/- 0.0104
-bench_alongside_no_read: 2.063 +/- 0.0086
-bench_alongside_with_read: 2.098 +/- 0.0123
+bench_innervtable_multiref_no_read: 1.649 +/- 0.0198
+bench_innervtable_multiref_with_read: 1.644 +/- 0.0104
+bench_innervtable_no_read: 2.063 +/- 0.0086
+bench_innervtable_with_read: 2.098 +/- 0.0123
 bench_fat_multiref_no_read: 1.704 +/- 0.0053
 bench_fat_multiref_with_read: 1.700 +/- 0.0007
 bench_fat_no_read: 1.707 +/- 0.0131
 bench_fat_with_read: 2.188 +/- 0.0125
 $ cargo run --release --bin vtable_bench 30 100 10000000
-bench_alongside_multiref_no_read: 1.666 +/- 0.0082
-bench_alongside_multiref_with_read: 1.666 +/- 0.0121
-bench_alongside_no_read: 2.077 +/- 0.0205
-bench_alongside_with_read: 2.100 +/- 0.0126
+bench_innervtable_multiref_no_read: 1.666 +/- 0.0082
+bench_innervtable_multiref_with_read: 1.666 +/- 0.0121
+bench_innervtable_no_read: 2.077 +/- 0.0205
+bench_innervtable_with_read: 2.100 +/- 0.0126
 bench_fat_multiref_no_read: 1.699 +/- 0.0014
 bench_fat_multiref_with_read: 1.702 +/- 0.0061
 bench_fat_no_read: 1.698 +/- 0.0059
 bench_fat_with_read: 2.184 +/- 0.0059
 $ cargo run --release --bin vtable_bench 30 10 100000000
-bench_alongside_multiref_no_read: 1.663 +/- 0.0082
-bench_alongside_multiref_with_read: 1.672 +/- 0.0230
-bench_alongside_no_read: 2.076 +/- 0.0141
-bench_alongside_with_read: 2.112 +/- 0.0160
+bench_innervtable_multiref_no_read: 1.663 +/- 0.0082
+bench_innervtable_multiref_with_read: 1.672 +/- 0.0230
+bench_innervtable_no_read: 2.076 +/- 0.0141
+bench_innervtable_with_read: 2.112 +/- 0.0160
 bench_fat_multiref_no_read: 1.709 +/- 0.0115
 bench_fat_multiref_with_read: 1.701 +/- 0.0025
 bench_fat_no_read: 1.702 +/- 0.0012

--- a/src/bin/bench_alongside_multiref_no_read.rs
+++ b/src/bin/bench_alongside_multiref_no_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_innervtable_multiref_no_read();
+    vtable_bench::bench_innervtable_multialias_no_read();
 }

--- a/src/bin/bench_alongside_multiref_no_read.rs
+++ b/src/bin/bench_alongside_multiref_no_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_alongside_multiref_no_read();
+    vtable_bench::bench_innervtable_multiref_no_read();
 }

--- a/src/bin/bench_alongside_multiref_with_read.rs
+++ b/src/bin/bench_alongside_multiref_with_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_innervtable_multiref_with_read();
+    vtable_bench::bench_innervtable_multialias_with_read();
 }

--- a/src/bin/bench_alongside_multiref_with_read.rs
+++ b/src/bin/bench_alongside_multiref_with_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_alongside_multiref_with_read();
+    vtable_bench::bench_innervtable_multiref_with_read();
 }

--- a/src/bin/bench_alongside_no_read.rs
+++ b/src/bin/bench_alongside_no_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_alongside_no_read();
+    vtable_bench::bench_innervtable_no_read();
 }

--- a/src/bin/bench_alongside_with_read.rs
+++ b/src/bin/bench_alongside_with_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_alongside_with_read();
+    vtable_bench::bench_innervtable_with_read();
 }

--- a/src/bin/bench_normal_multiref_no_read.rs
+++ b/src/bin/bench_normal_multiref_no_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_normal_multiref_no_read();
+    vtable_bench::bench_fat_multiref_no_read();
 }

--- a/src/bin/bench_normal_multiref_no_read.rs
+++ b/src/bin/bench_normal_multiref_no_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_fat_multiref_no_read();
+    vtable_bench::bench_fat_multialias_no_read();
 }

--- a/src/bin/bench_normal_multiref_with_read.rs
+++ b/src/bin/bench_normal_multiref_with_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_fat_multiref_with_read();
+    vtable_bench::bench_fat_multialias_with_read();
 }

--- a/src/bin/bench_normal_multiref_with_read.rs
+++ b/src/bin/bench_normal_multiref_with_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_normal_multiref_with_read();
+    vtable_bench::bench_fat_multiref_with_read();
 }

--- a/src/bin/bench_normal_no_read.rs
+++ b/src/bin/bench_normal_no_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_normal_no_read();
+    vtable_bench::bench_fat_no_read();
 }

--- a/src/bin/bench_normal_with_read.rs
+++ b/src/bin/bench_normal_with_read.rs
@@ -1,3 +1,3 @@
 fn main() {
-    vtable_bench::bench_normal_with_read();
+    vtable_bench::bench_fat_with_read();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,8 @@ fn vec_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
     // reuse it. With the coerce_unsized feature turned on, we can do this in a marginally cleverer
     // way, but the outcome is the same.
     let vtable = {
-        let b: *const dyn GetVal = Box::into_raw(Box::new(S::new()));
+        let s = S::new();
+        let b: &dyn GetVal = &s;
         let (_, vtable) = unsafe { transmute::<_, (usize, usize)>(b) };
         vtable
     };
@@ -217,7 +218,8 @@ pub fn bench_innervtable_with_read() {
 fn vec_multialias_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
     let mut v = Vec::with_capacity(*VEC_SIZE);
     let vtable = {
-        let b: *const dyn GetVal = Box::into_raw(Box::new(S::new()));
+        let s = S::new();
+        let b: &dyn GetVal = &s;
         let (_, vtable) = unsafe { transmute::<_, (usize, usize)>(b) };
         vtable
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,38 +116,38 @@ pub fn bench_fat_with_read() {
     });
 }
 
-fn vec_multiref<S: 'static + New + GetVal>() -> Vec<*mut dyn GetVal> {
+fn vec_multialias<S: 'static + New + GetVal>() -> Vec<*mut dyn GetVal> {
     vec![Box::into_raw(Box::new(S::new())); *VEC_SIZE]
 }
 
-fn clean_vec_multiref(v: Vec<*mut dyn GetVal>) {
+fn clean_vec_multialias(v: Vec<*mut dyn GetVal>) {
     unsafe {
         Box::from_raw(v[0]);
     }
 }
 
-pub fn bench_fat_multiref_no_read() {
+pub fn bench_fat_multialias_no_read() {
     assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
     assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
-    let v = vec_multiref::<SNoRead>();
+    let v = vec_multialias::<SNoRead>();
     time(|| {
         for &e in &v {
             assert_eq!(unsafe { (&*e).val() }, VAL_NOREAD);
         }
     });
-    clean_vec_multiref(v);
+    clean_vec_multialias(v);
 }
 
-pub fn bench_fat_multiref_with_read() {
+pub fn bench_fat_multialias_with_read() {
     assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
     assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
-    let v = vec_multiref::<SWithRead>();
+    let v = vec_multialias::<SWithRead>();
     time(|| {
         for &e in &v {
             assert_eq!(unsafe { (&*e).val() }, VAL_WITHREAD);
         }
     });
-    clean_vec_multiref(v);
+    clean_vec_multialias(v);
 }
 
 fn vec_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
@@ -214,7 +214,7 @@ pub fn bench_innervtable_with_read() {
     clean_vec_vtable(v);
 }
 
-fn vec_multiref_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
+fn vec_multialias_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
     let mut v = Vec::with_capacity(*VEC_SIZE);
     let vtable = {
         let b: *const dyn GetVal = Box::into_raw(Box::new(S::new()));
@@ -239,14 +239,14 @@ fn vec_multiref_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
     v
 }
 
-fn clean_multiref_table(v: Vec<*mut ()>) {
+fn clean_multialias_table(v: Vec<*mut ()>) {
     unsafe {
         Box::from_raw(v[0]);
     }
 }
 
-pub fn bench_innervtable_multiref_no_read() {
-    let v = vec_multiref_vtable::<SNoRead>();
+pub fn bench_innervtable_multialias_no_read() {
+    let v = vec_multialias_vtable::<SNoRead>();
     time(|| {
         for &e in &v {
             let vtable = unsafe { *(e as *const usize) };
@@ -255,11 +255,11 @@ pub fn bench_innervtable_multiref_no_read() {
             assert_eq!(unsafe { (&*b).val() }, VAL_NOREAD);
         }
     });
-    clean_multiref_table(v);
+    clean_multialias_table(v);
 }
 
-pub fn bench_innervtable_multiref_with_read() {
-    let v = vec_multiref_vtable::<SWithRead>();
+pub fn bench_innervtable_multialias_with_read() {
+    let v = vec_multialias_vtable::<SWithRead>();
     time(|| {
         for &e in &v {
             let vtable = unsafe { *(e as *const usize) };
@@ -268,5 +268,5 @@ pub fn bench_innervtable_multiref_with_read() {
             assert_eq!(unsafe { (&*b).val() }, VAL_WITHREAD);
         }
     });
-    clean_multiref_table(v);
+    clean_multialias_table(v);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ fn clean_vec_vtable(v: Vec<*mut ()>) {
     }
 }
 
-pub fn bench_alongside_no_read() {
+pub fn bench_innervtable_no_read() {
     let v = vec_vtable::<SNoRead>();
     time(|| {
         for &e in &v {
@@ -201,7 +201,7 @@ pub fn bench_alongside_no_read() {
     clean_vec_vtable(v);
 }
 
-pub fn bench_alongside_with_read() {
+pub fn bench_innervtable_with_read() {
     let v = vec_vtable::<SWithRead>();
     time(|| {
         for &e in &v {
@@ -245,7 +245,7 @@ fn clean_multiref_table(v: Vec<*mut ()>) {
     }
 }
 
-pub fn bench_alongside_multiref_no_read() {
+pub fn bench_innervtable_multiref_no_read() {
     let v = vec_multiref_vtable::<SNoRead>();
     time(|| {
         for &e in &v {
@@ -258,7 +258,7 @@ pub fn bench_alongside_multiref_no_read() {
     clean_multiref_table(v);
 }
 
-pub fn bench_alongside_multiref_with_read() {
+pub fn bench_innervtable_multiref_with_read() {
     let v = vec_multiref_vtable::<SWithRead>();
     time(|| {
         for &e in &v {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ fn vec_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
         let s = S::new();
         let b = unsafe {
             let (_, vtable) = transmute::<&dyn GetVal, (usize, usize)>(&s);
-            let b: *mut usize = alloc(layout) as *mut usize;
+            let b = alloc(layout) as *mut usize;
             b.copy_from(&vtable, 1);
             (b.add(1) as *mut S).copy_from(&s, 1);
             b as *mut ()
@@ -216,7 +216,7 @@ fn vec_multialias_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
         let s = S::new();
         let b = unsafe {
             let (_, vtable) = transmute::<&dyn GetVal, (usize, usize)>(&s);
-            let b: *mut usize = alloc(layout) as *mut usize;
+            let b = alloc(layout) as *mut usize;
             b.copy_from(&vtable, 1);
             (b.add(1) as *mut S).copy_from(&s, 1);
             b as *mut S as *mut dyn GetVal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ fn vec_normal<S: 'static + New + GetVal>() -> Vec<Box<dyn GetVal>> {
     v
 }
 
-pub fn bench_normal_no_read() {
+pub fn bench_fat_no_read() {
     assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
     assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
     let v = vec_normal::<SNoRead>();
@@ -105,7 +105,7 @@ pub fn bench_normal_no_read() {
     });
 }
 
-pub fn bench_normal_with_read() {
+pub fn bench_fat_with_read() {
     assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
     assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
     let v = vec_normal::<SWithRead>();
@@ -126,7 +126,7 @@ fn clean_vec_multiref(v: Vec<*mut dyn GetVal>) {
     }
 }
 
-pub fn bench_normal_multiref_no_read() {
+pub fn bench_fat_multiref_no_read() {
     assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
     assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
     let v = vec_multiref::<SNoRead>();
@@ -138,7 +138,7 @@ pub fn bench_normal_multiref_no_read() {
     clean_vec_multiref(v);
 }
 
-pub fn bench_normal_multiref_with_read() {
+pub fn bench_fat_multiref_with_read() {
     assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
     assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
     let v = vec_multiref::<SWithRead>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub fn bench_normal_multiref_with_read() {
     clean_vec_multiref(v);
 }
 
-fn vec_vtable<S: 'static + New + GetVal>() -> Vec<*mut u8> {
+fn vec_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
     assert_eq!(size_of::<Box<()>>(), size_of::<usize>());
     assert_eq!(size_of::<Box<dyn GetVal>>(), size_of::<usize>() * 2);
     let mut v = Vec::with_capacity(*VEC_SIZE);
@@ -173,14 +173,14 @@ fn vec_vtable<S: 'static + New + GetVal>() -> Vec<*mut u8> {
             let b: *mut usize = alloc(layout) as *mut usize;
             b.copy_from(&vtable, 1);
             (b.add(1) as *mut S).copy_from(&S::new(), 1);
-            b as *mut u8
+            b as *mut ()
         };
         v.push(b);
     }
     v
 }
 
-fn clean_vec_vtable(v: Vec<*mut u8>) {
+fn clean_vec_vtable(v: Vec<*mut ()>) {
     for e in v {
         unsafe {
             Box::from_raw(e);
@@ -214,7 +214,7 @@ pub fn bench_alongside_with_read() {
     clean_vec_vtable(v);
 }
 
-fn vec_multiref_vtable<S: 'static + New + GetVal>() -> Vec<*mut u8> {
+fn vec_multiref_vtable<S: 'static + New + GetVal>() -> Vec<*mut ()> {
     let mut v = Vec::with_capacity(*VEC_SIZE);
     let vtable = {
         let b: *const dyn GetVal = Box::into_raw(Box::new(S::new()));
@@ -230,7 +230,7 @@ fn vec_multiref_vtable<S: 'static + New + GetVal>() -> Vec<*mut u8> {
             (b.add(1) as *mut S).copy_from(&S::new(), 1);
             b as *mut S as *mut dyn GetVal
         };
-        let (ptr, _) = unsafe { transmute::<_, (*mut u8, usize)>(b) };
+        let (ptr, _) = unsafe { transmute::<_, (*mut (), usize)>(b) };
         ptr
     };
     for _ in 0..*VEC_SIZE {
@@ -239,7 +239,7 @@ fn vec_multiref_vtable<S: 'static + New + GetVal>() -> Vec<*mut u8> {
     v
 }
 
-fn clean_multiref_table(v: Vec<*mut u8>) {
+fn clean_multiref_table(v: Vec<*mut ()>) {
     unsafe {
         Box::from_raw(v[0]);
     }


### PR DESCRIPTION
This PR has no meaningful effect on the run-time behaviour of the benchmarks (though it does slightly change the setup and teardown), but it does make the terminology clearer, and quite a bit of the code simpler. Each commit should be self-contained.