### PR TITLE
Rename "inner vtable" to "inner vpointer".

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ nothing, however.
 Each benchmark creates one or more trait objects, puts them in a vector, and
 then iterates over that vector calling a method:
 
-* The `fat` benchmarks use fat pointers and the `innervtable` benchmarks store
+* The `fat` benchmarks use fat pointers and the `innervpointer` benchmarks store
   the vtable alongside the data itself (recreating fat pointers on an as-needed
   basis).
 
@@ -72,35 +72,35 @@ bench_fat_multialias_no_read: 1.628 +/- 0.0019
 bench_fat_multialias_with_read: 1.630 +/- 0.0030
 bench_fat_no_read: 1.627 +/- 0.0003
 bench_fat_with_read: 1.677 +/- 0.0045
-bench_innervtable_multialias_no_read: 1.628 +/- 0.0011
-bench_innervtable_multialias_with_read: 1.627 +/- 0.0002
-bench_innervtable_no_read: 1.660 +/- 0.0032
-bench_innervtable_with_read: 1.671 +/- 0.0023
+bench_innervpointer_multialias_no_read: 1.628 +/- 0.0011
+bench_innervpointer_multialias_with_read: 1.627 +/- 0.0002
+bench_innervpointer_no_read: 1.660 +/- 0.0032
+bench_innervpointer_with_read: 1.671 +/- 0.0023
 $ cargo run --release --bin vtable_bench 30 1000 1000000
 bench_fat_multialias_no_read: 1.709 +/- 0.0104
 bench_fat_multialias_with_read: 1.709 +/- 0.0099
 bench_fat_no_read: 1.708 +/- 0.0138
 bench_fat_with_read: 2.152 +/- 0.0103
-bench_innervtable_multialias_no_read: 1.641 +/- 0.0007
-bench_innervtable_multialias_with_read: 1.644 +/- 0.0115
-bench_innervtable_no_read: 2.111 +/- 0.0054
-bench_innervtable_with_read: 2.128 +/- 0.0090
+bench_innervpointer_multialias_no_read: 1.641 +/- 0.0007
+bench_innervpointer_multialias_with_read: 1.644 +/- 0.0115
+bench_innervpointer_no_read: 2.111 +/- 0.0054
+bench_innervpointer_with_read: 2.128 +/- 0.0090
 $ cargo run --release --bin vtable_bench 30 100 10000000
 bench_fat_multialias_no_read: 1.700 +/- 0.0012
 bench_fat_multialias_with_read: 1.707 +/- 0.0128
 bench_fat_no_read: 1.694 +/- 0.0014
 bench_fat_with_read: 2.182 +/- 0.0071
-bench_innervtable_multialias_no_read: 1.666 +/- 0.0006
-bench_innervtable_multialias_with_read: 1.681 +/- 0.0240
-bench_innervtable_no_read: 2.129 +/- 0.0046
-bench_innervtable_with_read: 2.152 +/- 0.0099
+bench_innervpointer_multialias_no_read: 1.666 +/- 0.0006
+bench_innervpointer_multialias_with_read: 1.681 +/- 0.0240
+bench_innervpointer_no_read: 2.129 +/- 0.0046
+bench_innervpointer_with_read: 2.152 +/- 0.0099
 $ cargo run --release --bin vtable_bench 30 10 100000000
 bench_fat_multialias_no_read: 1.708 +/- 0.0101
 bench_fat_multialias_with_read: 1.702 +/- 0.0038
 bench_fat_no_read: 1.705 +/- 0.0126
 bench_fat_with_read: 2.184 +/- 0.0046
-bench_innervtable_multialias_no_read: 1.664 +/- 0.0081
-bench_innervtable_multialias_with_read: 1.666 +/- 0.0101
-bench_innervtable_no_read: 2.146 +/- 0.0138
-bench_innervtable_with_read: 2.169 +/- 0.0125
+bench_innervpointer_multialias_no_read: 1.664 +/- 0.0081
+bench_innervpointer_multialias_with_read: 1.666 +/- 0.0101
+bench_innervpointer_no_read: 2.146 +/- 0.0138
+bench_innervpointer_with_read: 2.169 +/- 0.0125
 ```

--- a/src/bin/bench_innervpointer_multialias_no_read.rs
+++ b/src/bin/bench_innervpointer_multialias_no_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_innervpointer_multialias_no_read();
+}

--- a/src/bin/bench_innervpointer_multialias_with_read.rs
+++ b/src/bin/bench_innervpointer_multialias_with_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_innervpointer_multialias_with_read();
+}

--- a/src/bin/bench_innervpointer_no_read.rs
+++ b/src/bin/bench_innervpointer_no_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_innervpointer_no_read();
+}

--- a/src/bin/bench_innervpointer_with_read.rs
+++ b/src/bin/bench_innervpointer_with_read.rs
@@ -1,0 +1,3 @@
+fn main() {
+    vtable_bench::bench_innervpointer_with_read();
+}

--- a/src/bin/bench_innervtable_multialias_no_read.rs
+++ b/src/bin/bench_innervtable_multialias_no_read.rs
@@ -1,3 +1,0 @@
-fn main() {
-    vtable_bench::bench_innervtable_multialias_no_read();
-}

--- a/src/bin/bench_innervtable_multialias_with_read.rs
+++ b/src/bin/bench_innervtable_multialias_with_read.rs
@@ -1,3 +1,0 @@
-fn main() {
-    vtable_bench::bench_innervtable_multialias_with_read();
-}

--- a/src/bin/bench_innervtable_no_read.rs
+++ b/src/bin/bench_innervtable_no_read.rs
@@ -1,3 +1,0 @@
-fn main() {
-    vtable_bench::bench_innervtable_no_read();
-}

--- a/src/bin/bench_innervtable_with_read.rs
+++ b/src/bin/bench_innervtable_with_read.rs
@@ -1,3 +1,0 @@
-fn main() {
-    vtable_bench::bench_innervtable_with_read();
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ fn clean_vec_vtable(v: Vec<*mut ()>) {
     }
 }
 
-pub fn bench_innervtable_no_read() {
+pub fn bench_innervpointer_no_read() {
     let v = vec_vtable::<SNoRead>();
     time(|| {
         for &e in &v {
@@ -195,7 +195,7 @@ pub fn bench_innervtable_no_read() {
     clean_vec_vtable(v);
 }
 
-pub fn bench_innervtable_with_read() {
+pub fn bench_innervpointer_with_read() {
     let v = vec_vtable::<SWithRead>();
     time(|| {
         for &e in &v {
@@ -230,7 +230,7 @@ fn clean_multialias_table(v: Vec<*mut ()>) {
     }
 }
 
-pub fn bench_innervtable_multialias_no_read() {
+pub fn bench_innervpointer_multialias_no_read() {
     let v = vec_multialias_vtable::<SNoRead>();
     time(|| {
         for &e in &v {
@@ -243,7 +243,7 @@ pub fn bench_innervtable_multialias_no_read() {
     clean_multialias_table(v);
 }
 
-pub fn bench_innervtable_multialias_with_read() {
+pub fn bench_innervpointer_multialias_with_read() {
     let v = vec_multialias_vtable::<SWithRead>();
     time(|| {
         for &e in &v {


### PR DESCRIPTION
This terminology was suggested by Jake, because we don't store the vtable in an object, but a pointer to the vtable. "vptr" is terminology used by LLVM and some other compilers, so it's not without precedent.

[I've verified that the numbers haven't changed with a quick run, so the search and replace here is OK.]